### PR TITLE
SingleTable option for grouping metrics 

### DIFF
--- a/plugins/outputs/azure_data_explorer/README.md
+++ b/plugins/outputs/azure_data_explorer/README.md
@@ -22,14 +22,32 @@ This plugin writes metrics collected by any of the input plugins of Telegraf to 
 
   ## Timeout for Azure Data Explorer operations
   # timeout = "15s"
+  
+  ## Type of metrics grouping used when pushing to Azure Data Explorer. 
+  ## Default is "TablePerMetric" for one table per different metric. 
+  ## For more information, please check the plugin README.
+  # metrics_grouping_type = "TablePerMetric"
+  
+  ## Name of the single table to store all the metrics (Only needed if metrics_grouping_type is "SingleTable").
+  # table_name = ""
+
 
 ```
 
 ## Metrics Grouping
 
+### TablePerMetric
+
 The plugin will group the metrics by the metric name, and will send each group of metrics to an Azure Data Explorer table. If the table doesn't exist the plugin will create the table, if the table exists then the plugin will try to merge the Telegraf metric schema to the existing table. For more information about the merge process check the [`.create-merge` documentation](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/create-merge-table-command).
 
 The table name will match the `name` property of the metric, this means that the name of the metric should comply with the Azure Data Explorer table naming constraints in case you plan to add a prefix to the metric name.
+
+This is the default behaviour if no value is given to `metrics_grouping_type` in the config file.
+
+### SingleTable
+
+The plugin will send all the metrics received to a single Azure Data Explorer table. The name of the table must be supplied via `table_name` the config file. If the table doesn't exist the plugin will create the table, if the table exists then the plugin will try to merge the Telegraf metric schema to the existing table. For more information about the merge process check the [`.create-merge` documentation](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/create-merge-table-command). 
+
 
 ## Tables Schema
 

--- a/plugins/outputs/azure_data_explorer/README.md
+++ b/plugins/outputs/azure_data_explorer/README.md
@@ -36,13 +36,14 @@ This plugin writes metrics collected by any of the input plugins of Telegraf to 
 
 ## Metrics Grouping
 
+Metrics can be grouped in two ways to be sent to Azure Data Explorer. To specify which metric grouping type the plugin should use, the respective value should be given to the `metrics_grouping_type` in the config file. If no value is given to `metrics_grouping_type`, by default, the metrics will be grouped using `TablePerMetric`.
+
 ### TablePerMetric
 
 The plugin will group the metrics by the metric name, and will send each group of metrics to an Azure Data Explorer table. If the table doesn't exist the plugin will create the table, if the table exists then the plugin will try to merge the Telegraf metric schema to the existing table. For more information about the merge process check the [`.create-merge` documentation](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/create-merge-table-command).
 
 The table name will match the `name` property of the metric, this means that the name of the metric should comply with the Azure Data Explorer table naming constraints in case you plan to add a prefix to the metric name.
 
-This is the default behaviour if no value is given to `metrics_grouping_type` in the config file.
 
 ### SingleTable
 

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -32,23 +32,10 @@ type AzureDataExplorer struct {
 	createIngestor  ingestorFactory
 }
 
-type MetricsGroupingType int
-
 const (
-	TablePerMetric MetricsGroupingType = iota
-	SingleTable
+	TablePerMetric = "TablePerMetric"
+	SingleTable    = "SingleTable"
 )
-
-func (m MetricsGroupingType) String() string {
-	switch m {
-	case TablePerMetric:
-		return "TablePerMetric"
-	case SingleTable:
-		return "SingleTable"
-	default:
-		return "unknown"
-	}
-}
 
 type localIngestor interface {
 	FromReader(ctx context.Context, reader io.Reader, options ...ingest.FileOption) (*ingest.Result, error)
@@ -118,7 +105,7 @@ func (adx *AzureDataExplorer) Close() error {
 }
 
 func (adx *AzureDataExplorer) Write(metrics []telegraf.Metric) error {
-	if adx.MetricsGrouping == TablePerMetric.String() {
+	if adx.MetricsGrouping == TablePerMetric {
 		return adx.writeTablePerMetric(metrics)
 	} else {
 		return adx.writeSingleTable(metrics)
@@ -232,13 +219,13 @@ func (adx *AzureDataExplorer) Init() error {
 		return errors.New("Database configuration cannot be empty")
 	}
 
-	if adx.MetricsGrouping == SingleTable.String() && adx.TableName == "" {
+	if adx.MetricsGrouping == SingleTable && adx.TableName == "" {
 		return errors.New("Table name cannot be empty for SingleTable metrics grouping type")
 	}
 	if adx.MetricsGrouping == "" {
-		adx.MetricsGrouping = TablePerMetric.String()
+		adx.MetricsGrouping = TablePerMetric
 	}
-	if !(adx.MetricsGrouping == SingleTable.String() || adx.MetricsGrouping == TablePerMetric.String() || adx.MetricsGrouping == "") {
+	if !(adx.MetricsGrouping == SingleTable || adx.MetricsGrouping == TablePerMetric || adx.MetricsGrouping == "") {
 		return errors.New("Metrics grouping type is not valid")
 	}
 

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -33,8 +33,8 @@ type AzureDataExplorer struct {
 }
 
 const (
-	TablePerMetric = "TablePerMetric"
-	SingleTable    = "SingleTable"
+	tablePerMetric = "TablePerMetric"
+	singleTable    = "SingleTable"
 )
 
 type localIngestor interface {
@@ -107,7 +107,7 @@ func (adx *AzureDataExplorer) Close() error {
 }
 
 func (adx *AzureDataExplorer) Write(metrics []telegraf.Metric) error {
-	if adx.MetricsGrouping == TablePerMetric {
+	if adx.MetricsGrouping == tablePerMetric {
 		return adx.writeTablePerMetric(metrics)
 	} else {
 		return adx.writeSingleTable(metrics)
@@ -223,13 +223,13 @@ func (adx *AzureDataExplorer) Init() error {
 		return errors.New("Database configuration cannot be empty")
 	}
 
-	if adx.MetricsGrouping == SingleTable && adx.TableName == "" {
+	if adx.MetricsGrouping == singleTable && adx.TableName == "" {
 		return errors.New("Table name cannot be empty for SingleTable metrics grouping type")
 	}
 	if adx.MetricsGrouping == "" {
-		adx.MetricsGrouping = TablePerMetric
+		adx.MetricsGrouping = tablePerMetric
 	}
-	if !(adx.MetricsGrouping == SingleTable || adx.MetricsGrouping == TablePerMetric || adx.MetricsGrouping == "") {
+	if !(adx.MetricsGrouping == singleTable || adx.MetricsGrouping == tablePerMetric) {
 		return errors.New("Metrics grouping type is not valid")
 	}
 

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -68,7 +68,9 @@ func (adx *AzureDataExplorer) SampleConfig() string {
   ## Timeout for Azure Data Explorer operations
   # timeout = "15s"
 
-  ## Metrics grouping type for metrics in Azure Data Explorer. Default is the "TablePerMetric" for one table per different metric. Other options include "SingleTable" for having all metrics in one table.
+  ## Type of metrics grouping used when pushing to Azure Data Explorer. 
+  ## Default is "TablePerMetric" for one table per different metric. 
+  ## For more information, please check the plugin README.
   # metrics_grouping_type = "TablePerMetric"
 
   ## Name of the single table to store all the metrics (Only needed if metrics_grouping_type is "SingleTable").

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
@@ -45,9 +45,7 @@ func TestWrite(t *testing.T) {
 			createIngestor:  createFakeIngestor,
 			metricsGrouping: "TablePerMetric",
 			expected: map[string]interface{}{
-				"metricName":                "test1",
-				"createTableCommand":        "",
-				"createTableMappingCommand": "",
+				"metricName": "test1",
 			},
 		},
 		{
@@ -62,9 +60,7 @@ func TestWrite(t *testing.T) {
 			createIngestor:  createFakeIngestor,
 			metricsGrouping: "TablePerMetric",
 			expected: map[string]interface{}{
-				"metricName":                "test1",
-				"createTableCommand":        "",
-				"createTableMappingCommand": "",
+				"metricName": "test1",
 			},
 			expectedWriteError: "creating table for \"test1\" failed: Something went wrong",
 		},
@@ -81,9 +77,7 @@ func TestWrite(t *testing.T) {
 			createIngestor:  createFakeIngestor,
 			metricsGrouping: "SingleTable",
 			expected: map[string]interface{}{
-				"metricName":                "test1",
-				"createTableCommand":        "",
-				"createTableMappingCommand": "",
+				"metricName": "test1",
 			},
 		},
 	}
@@ -116,7 +110,7 @@ func TestWrite(t *testing.T) {
 				expectedNameOfTable := expectedNameOfMetric
 				createdIngestor := plugin.ingesters[expectedNameOfMetric]
 
-				if tC.metricsGrouping == SingleTable {
+				if tC.metricsGrouping == singleTable {
 					expectedNameOfTable = tC.tableName
 					createdIngestor = plugin.ingesters[expectedNameOfTable]
 				}

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
@@ -27,6 +27,8 @@ func TestWrite(t *testing.T) {
 		inputMetric        []telegraf.Metric
 		client             *fakeClient
 		createIngestor     ingestorFactory
+		metricsGrouping    string
+		tableName          string
 		expected           map[string]interface{}
 		expectedWriteError string
 	}{
@@ -40,7 +42,8 @@ func TestWrite(t *testing.T) {
 					return &kusto.RowIterator{}, nil
 				},
 			},
-			createIngestor: createFakeIngestor,
+			createIngestor:  createFakeIngestor,
+			metricsGrouping: "TablePerMetric",
 			expected: map[string]interface{}{
 				"metricName":                "test1",
 				"createTableCommand":        "",
@@ -56,13 +59,32 @@ func TestWrite(t *testing.T) {
 					return nil, errors.New("Something went wrong")
 				},
 			},
-			createIngestor: createFakeIngestor,
+			createIngestor:  createFakeIngestor,
+			metricsGrouping: "TablePerMetric",
 			expected: map[string]interface{}{
 				"metricName":                "test1",
 				"createTableCommand":        "",
 				"createTableMappingCommand": "",
 			},
 			expectedWriteError: "creating table for \"test1\" failed: Something went wrong",
+		},
+		{
+			name:        "SingleTable metric grouping type",
+			inputMetric: testutil.MockMetrics(),
+			client: &fakeClient{
+				queries: make([]string, 0),
+				internalMgmt: func(f *fakeClient, ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+					f.queries = append(f.queries, query.String())
+					return &kusto.RowIterator{}, nil
+				},
+			},
+			createIngestor:  createFakeIngestor,
+			metricsGrouping: "SingleTable",
+			expected: map[string]interface{}{
+				"metricName":                "test1",
+				"createTableCommand":        "",
+				"createTableMappingCommand": "",
+			},
 		},
 	}
 
@@ -72,13 +94,15 @@ func TestWrite(t *testing.T) {
 			require.NoError(t, err)
 
 			plugin := AzureDataExplorer{
-				Endpoint:       "someendpoint",
-				Database:       "databasename",
-				Log:            testutil.Logger{},
-				client:         tC.client,
-				ingesters:      map[string]localIngestor{},
-				createIngestor: tC.createIngestor,
-				serializer:     serializer,
+				Endpoint:        "someendpoint",
+				Database:        "databasename",
+				Log:             testutil.Logger{},
+				MetricsGrouping: tC.metricsGrouping,
+				TableName:       tC.tableName,
+				client:          tC.client,
+				ingesters:       map[string]localIngestor{},
+				createIngestor:  tC.createIngestor,
+				serializer:      serializer,
 			}
 
 			errorInWrite := plugin.Write(testutil.MockMetrics())
@@ -89,15 +113,22 @@ func TestWrite(t *testing.T) {
 				require.NoError(t, errorInWrite)
 
 				expectedNameOfMetric := tC.expected["metricName"].(string)
+				expectedNameOfTable := expectedNameOfMetric
 				createdIngestor := plugin.ingesters[expectedNameOfMetric]
+
+				if tC.metricsGrouping == SingleTable {
+					expectedNameOfTable = tC.tableName
+					createdIngestor = plugin.ingesters[expectedNameOfTable]
+				}
+
 				require.NotNil(t, createdIngestor)
 				createdFakeIngestor := createdIngestor.(*fakeIngestor)
 				require.Equal(t, expectedNameOfMetric, createdFakeIngestor.actualOutputMetric["name"])
 
-				createTableString := fmt.Sprintf(createTableCommandExpected, expectedNameOfMetric)
+				createTableString := fmt.Sprintf(createTableCommandExpected, expectedNameOfTable)
 				require.Equal(t, createTableString, tC.client.queries[0])
 
-				createTableMappingString := fmt.Sprintf(createTableMappingCommandExpected, expectedNameOfMetric, expectedNameOfMetric)
+				createTableMappingString := fmt.Sprintf(createTableMappingCommandExpected, expectedNameOfTable, expectedNameOfTable)
 				require.Equal(t, createTableMappingString, tC.client.queries[1])
 			}
 		})


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

Allow users to define via config file how they would like the metrics grouped. Options include:
*  `TablePerMetric`: one table per metric type
*  `SingleTable`: single table for all metrics
